### PR TITLE
MSDKUI-1551 [Android] RP - Canceling setting waypoint creates an empt…

### DIFF
--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/Contracts.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/Contracts.kt
@@ -98,6 +98,14 @@ class CommonContracts {
     interface WaypointSelection : BaseContract<WaypointSelection> {
 
         /**
+         * Back icon is clicked.
+         *
+         * @param index index of [WaypointEntry].
+         * @param entry [WaypointEntry].
+         */
+        fun onBackClicked(index: Int?, entry: WaypointEntry?)
+
+        /**
          * Right icon is clicked.
          *
          * @param index index of [WaypointEntry].

--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionFragment.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionFragment.kt
@@ -111,6 +111,10 @@ class WaypointSelectionFragment() : RetainFragment(),
         presenter.updateCord(cord)
     }
 
+    override fun onBackClicked(index: Int?, entry: WaypointEntry?) {
+        (coordinator as? RoutingCoordinator)?.onWaypointSelectionCancelled(index, entry)
+    }
+
     override fun onRightIconClicked(index: Int?, entry: WaypointEntry?) {
         if (entry != null && entry.isValid) {
             (coordinator as? RoutingCoordinator)?.onWaypointSelected(index, entry)
@@ -149,9 +153,18 @@ class WaypointSelectionFragment() : RetainFragment(),
     interface Listener {
 
         /**
+         * Callback to be called when user cancel waypoint selection.
+         *
+         * @param index a integer if you want to track waypoint entry, useful like using in list, null otherwise.
+         * @param current WaypointEntry object.
+         */
+        fun onWaypointSelectionCancelled(index: Int?, current: WaypointEntry?)
+
+        /**
          * Callback to be called when user select a waypoint.
          *
          * @param index a integer if you want to track waypoint entry, useful like using in list, null otherwise.
+         * @param current WaypointEntry object.
          */
         fun onWaypointSelected(index: Int?, current: WaypointEntry)
     }

--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionPresenter.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionPresenter.kt
@@ -51,7 +51,11 @@ class WaypointSelectionPresenter() : BasePresenter<CommonContracts.WaypointSelec
      */
     fun setUpActionBar(appActionBar: AppActionBar?) {
         appActionBar?.run {
-            setBack(true, id = R.drawable.ic_clear_black_24dp)
+            setBack(true, id = R.drawable.ic_clear_black_24dp,
+                    clickListener = {
+                        contract?.onBackClicked(state.index, state.entry)
+                        activity.onBackPressed()
+                    })
             setTitle(value = context!!.getString(R.string.msdkui_waypoint_select_location))
             setRightIcon(id = R.drawable.ic_check_black_24dp,
                     accessibleValue = context!!.getString(R.string.msdkui_app_done),

--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/RoutePlannerFragment.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/RoutePlannerFragment.kt
@@ -194,6 +194,25 @@ class RoutePlannerFragment() : RetainFragment(), RoutingContracts.RoutePlanner {
     }
 
     /**
+     * Make action on waypoint selection cancelled - if this waypoint is invalid then remove it from list.
+     *
+     * @param index index within the list where selection been cancelled.
+     * @param current [WaypointEntry] that selection been cancelled.
+     */
+    fun waypointSelectionCancelled(index: Int?, current: WaypointEntry?) {
+        index ?: return
+        var removeWaypoint = true
+        current?.run {
+            if (isValid) removeWaypoint = false
+        }
+        waypointList?.run {
+            if (removeWaypoint && entriesCount > minWaypointItems) {
+                removeEntry(index)
+            }
+        }
+    }
+
+    /**
      * Listeners to be notified by route planner component.
      */
     interface Listener {

--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/RoutingCoordinator.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/RoutingCoordinator.kt
@@ -75,6 +75,10 @@ class RoutingCoordinator(private val context: Context, fragmentManager: Fragment
         selectionFragment.updatePosition(index, current)
     }
 
+    override fun onWaypointSelectionCancelled(index: Int?, current: WaypointEntry?) {
+        plannerFragment?.waypointSelectionCancelled(index, current)
+    }
+
     override fun onWaypointSelected(index: Int?, current: WaypointEntry) {
         if (index != null) {
             onBackPressed()

--- a/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionFragmentTest.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionFragmentTest.kt
@@ -26,6 +26,7 @@ import android.widget.TextView
 import com.here.android.mpa.common.GeoCoordinate
 import com.here.msdkui.routing.WaypointEntry
 import com.here.msdkuiapp.R
+import com.here.msdkuiapp.baseActivity
 import com.here.msdkuiapp.map.MapFragmentWrapper
 import com.here.msdkuiapp.routing.RoutingActivity
 import com.here.msdkuiapp.routing.RoutingCoordinator
@@ -74,6 +75,7 @@ class WaypointSelectionFragmentTest {
             presenter = mockPresenter
             mapFragment = mockMapFragment
             activityInstance = mockActivity
+            `when`(baseActivity).thenReturn(mockActivity)
             `when`(view).thenReturn(mockView)
         }
         with(fragment) {
@@ -126,13 +128,22 @@ class WaypointSelectionFragmentTest {
     }
 
     @Test
+    fun testOnBackClicked() {
+        val entry = mock(WaypointEntry::class.java)
+        val mockRoutingCoordinator = mock(RoutingCoordinator::class.java)
+        `when`(mockActivity.coordinator).thenReturn(mockRoutingCoordinator)
+        fragment.onBackClicked(8, entry)
+        verify(mockRoutingCoordinator).onWaypointSelectionCancelled(8, entry)
+    }
+
+    @Test
     fun testOnRightIconClick() {
         val entry = mock(WaypointEntry::class.java)
         `when`(entry.isValid).thenReturn(true)
         val mockRoutingCoordinator = mock(RoutingCoordinator::class.java)
         `when`(mockActivity.coordinator).thenReturn(mockRoutingCoordinator)
         fragment.onRightIconClicked(null, entry)
-        verify(mockRoutingCoordinator, times(0)).onWaypointSelected(anySafe(), anySafe())
+        verify(mockRoutingCoordinator).onWaypointSelected(null, entry)
     }
 
     @Test

--- a/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionPresenterTest.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/common/mapselection/WaypointSelectionPresenterTest.kt
@@ -16,6 +16,7 @@
 
 package com.here.msdkuiapp.common.mapselection
 
+import android.app.Activity
 import com.here.android.mpa.common.GeoCoordinate
 import com.here.android.mpa.routing.RouteWaypoint
 import com.here.android.mpa.search.*
@@ -62,11 +63,23 @@ class WaypointSelectionPresenterTest : BaseTest() {
 
     @Test
     fun testActionBar() {
+        val captorBackClickListener = argumentCaptor<() -> Unit>()
+        val captorRightIconClickListener = argumentCaptor<() -> Unit>()
         val actionBar = mock(AppActionBar::class.java)
+        val mockActivity = mock(Activity::class.java)
+        `when`(actionBar.activity).thenReturn(mockActivity)
+
         presenter.setUpActionBar(actionBar)
-        verify(actionBar).setBack(anyBoolean(), anyInt(), anySafe())
+        verify(actionBar).setBack(anyBoolean(), anyInt(), captorBackClickListener.capture())
         verify(actionBar).setTitle(anyBoolean(), anyString(), anyBoolean())
-        verify(actionBar).setRightIcon(anyBoolean(), anyInt(), anyString(), anySafe())
+        verify(actionBar).setRightIcon(anyBoolean(), anyInt(), anyString(), captorRightIconClickListener.capture())
+
+        captorBackClickListener.value.invoke()
+        verify(mockContract).onBackClicked(anySafe(), anySafe())
+        verify(mockActivity).onBackPressed()
+
+        captorRightIconClickListener.value.invoke()
+        verify(mockContract).onRightIconClicked(anySafe(), anySafe())
     }
 
     @Test

--- a/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/routing/RoutePlannerFragmentTest.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/routing/RoutePlannerFragmentTest.kt
@@ -207,4 +207,29 @@ class RoutePlannerFragmentTest : BaseTest() {
         fragment.updateActionBar(false, false, false)
         verify(presenter).updateActionBar(false, false, false)
     }
+
+    @Test
+    fun testWaypointSelectionCancelled() {
+        val waypointList = fragment.view!!.waypoint_list
+        val entry = mock(WaypointEntry::class.java)
+
+        fragment.waypointSelectionCancelled(null, null)
+        fragment.waypointSelectionCancelled(0, null)
+        `when`(entry.isValid).thenReturn(false)
+        fragment.waypointSelectionCancelled(0, entry)
+        `when`(entry.isValid).thenReturn(true)
+        fragment.waypointSelectionCancelled(0, entry)
+        // All above calls should not remove any entry from waypointList because of incorrect
+        // data and min waypoint items requirement.
+        assertEquals(waypointList.entriesCount, 2)
+
+        waypointList.addEntry(entry)
+        `when`(entry.isValid).thenReturn(true)
+        fragment.waypointSelectionCancelled(2, entry)
+        assertEquals(waypointList.entriesCount, 3)
+
+        `when`(entry.isValid).thenReturn(false)
+        fragment.waypointSelectionCancelled(2, entry)
+        assertEquals(waypointList.entriesCount, 2)
+    }
 }

--- a/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/routing/RoutingCoordinatorTest.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/routing/RoutingCoordinatorTest.kt
@@ -123,6 +123,13 @@ class RoutingCoordinatorTest : BaseTest() {
     }
 
     @Test
+    fun testOnWaypointSelectionCancelled() {
+        `when`(mockFragmentManager.findFragmentById(R.id.route_top_container)).thenReturn(mockRoutePlannerFragment)
+        coordinator.onWaypointSelectionCancelled(null, null)
+        verify(mockRoutePlannerFragment).waypointSelectionCancelled(null, null)
+    }
+
+    @Test
     fun testOnWaypointSelected() {
         `when`(mockFragmentManager.findFragmentById(R.id.route_top_container)).thenReturn(mockRoutePlannerFragment)
         val mockWaypointEntry = mock(WaypointEntry::class.java)


### PR DESCRIPTION
…y waypoint item to list and results in a crash

Route Planner - empty waypoints will no longer be added when exiting waypoint
selection using X icon. Updated unit tests.

Signed-off-by: Tadeusz Staszak <36914750+tstaszak89@users.noreply.github.com>