### PR TITLE
[Android] Accessibility - Guidance - Focus starts at the bottom of the screen

### DIFF
--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/AppActionBar.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/AppActionBar.kt
@@ -22,6 +22,7 @@ import android.support.v7.widget.Toolbar
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
+import com.here.android.mpa.routing.RouteOptions
 import com.here.msdkuiapp.*
 import com.here.msdkuiapp.about.AboutActivity
 
@@ -71,6 +72,12 @@ class AppActionBar(val activity: Activity) {
             }
         }
     }
+
+    /**
+     * Gets title view reference of action bar.
+     */
+    val titleView: View?
+        get() = activity.supportActionBar?.customView?.findViewById(R.id.ac_title) as? TextView
 
     /**
      * Sets action bar title with given options.

--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/AppActionBar.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/AppActionBar.kt
@@ -22,7 +22,6 @@ import android.support.v7.widget.Toolbar
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
-import com.here.android.mpa.routing.RouteOptions
 import com.here.msdkuiapp.*
 import com.here.msdkuiapp.about.AboutActivity
 

--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/routepreview/RoutePreviewFragment.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/common/routepreview/RoutePreviewFragment.kt
@@ -23,6 +23,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import com.here.android.mpa.routing.Route
 import com.here.msdkui.routing.WaypointEntry
 import com.here.msdkuiapp.*
@@ -96,6 +97,7 @@ class RoutePreviewFragment : Fragment(), GuidanceContracts.RoutePreview {
             list_end_divider.visibility = View.GONE
             place_holder.visibility = View.VISIBLE
         } else {
+            activity?.appActionBar?.titleView?.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
             see_steps.text = activity!!.getText(com.here.msdkuiapp.R.string.msdkui_app_guidance_button_showmap)
             guidance_maneuver_list.visibility = View.VISIBLE
             list_end_divider.visibility = View.VISIBLE

--- a/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/common/AppActionBarTest.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/test/java/com/here/msdkuiapp/common/AppActionBarTest.kt
@@ -28,6 +28,7 @@ import com.here.msdkuiapp.about.AboutActivity
 import com.here.msdkuiapp.setResourceWithTag
 import com.here.testutils.BaseTest
 import com.here.testutils.argumentCaptor
+import junit.framework.Assert.assertNotNull
 import junit.framework.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -114,6 +115,7 @@ class AppActionBarTest : BaseTest() {
         appActionBar.setTitle()
         verify(mockTextView).visibility = eq(View.VISIBLE)
         verify(mockTextView).text = eq("")
+        assertNotNull(appActionBar.titleView)
     }
 
     @Test


### PR DESCRIPTION
This changes send accessibility focus to title so that user can screenread items in correct and logical order.

Signed-off-by: Vijay Yadav <5671997+imvjk@users.noreply.github.com>