### PR TITLE
MSDKUI-1695 Wrong content description for add/swap RP buttons

### DIFF
--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/IconButton.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/IconButton.kt
@@ -65,7 +65,6 @@ class IconButton(context: Context, attrs: AttributeSet? = null, defStyleAttr: In
      * Updates the foreground image based on the button type.
      */
     private fun updateImage() {
-        contentDescription = type.name
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             setImageResource(type.value)
         } else {


### PR DESCRIPTION
Custom IconButton was overwriting content description attribute.

Signed-off-by: Marcin Lawicki <41331357+m1awicki@users.noreply.github.com>