### PR TITLE
Remove extra attributes for TravelTimePickerTabLayout

### DIFF
--- a/MSDKUIKit/MSDKUILib/src/main/res/values/style.xml
+++ b/MSDKUIKit/MSDKUILib/src/main/res/values/style.xml
@@ -539,8 +539,6 @@
     <style name="TravelTimePickerTabLayout">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">@dimen/picker_tab_height</item>
-        <item name="tabGravity">fill</item>
-        <item name="tabMode">fixed</item>
     </style>
 
     <style name="TravelTimePickerTabLeaveItem">


### PR DESCRIPTION
`TravelTimePickerTabLayout` has extra attributes that are not declared as attributes as `attrs.xml` and do not seem to be used anywhere in `TravelTimePicker.java` anyway. These were preventing my app from compiling. 

I thought it was odd since I am using a similar setup to one of the demo apps, but maybe since I am targeting a higher SDK version this came up?

I was getting `Error:(...) style attribute '@...' not found` for these two attributes before removing these.