### PR TITLE
Remove un-used route in presenter

### DIFF
--- a/MSDKUIKit/MSDKUILib/src/main/java/com/here/msdkui/guidance/GuidanceManeuverPresenter.java
+++ b/MSDKUIKit/MSDKUILib/src/main/java/com/here/msdkui/guidance/GuidanceManeuverPresenter.java
@@ -22,7 +22,6 @@ import android.graphics.Bitmap;
 import com.here.android.mpa.common.Image;
 import com.here.android.mpa.guidance.NavigationManager;
 import com.here.android.mpa.routing.Maneuver;
-import com.here.android.mpa.routing.Route;
 import com.here.android.mpa.routing.Signpost;
 import com.here.msdkui.R;
 import com.here.msdkui.guidance.base.BaseGuidancePresenter;
@@ -49,11 +48,9 @@ public class GuidanceManeuverPresenter extends BaseGuidancePresenter {
      *         a {@link Context} to retrieve resources.
      * @param navigationManager
      *         a {@link NavigationManager} to be used for guidance handling.
-     * @param route
-     *         a route to be used for guidance.
      */
-    public GuidanceManeuverPresenter(Context context, NavigationManager navigationManager, Route route) {
-        super(navigationManager, route);
+    public GuidanceManeuverPresenter(Context context, NavigationManager navigationManager) {
+        super(navigationManager, null);
         mContext = context;
     }
 

--- a/MSDKUIKit/MSDKUILib/src/main/java/com/here/msdkui/guidance/GuidanceNextManeuverPresenter.java
+++ b/MSDKUIKit/MSDKUILib/src/main/java/com/here/msdkui/guidance/GuidanceNextManeuverPresenter.java
@@ -20,7 +20,6 @@ import android.content.Context;
 
 import com.here.android.mpa.guidance.NavigationManager;
 import com.here.android.mpa.routing.Maneuver;
-import com.here.android.mpa.routing.Route;
 import com.here.msdkui.common.DistanceFormatterUtil;
 import com.here.msdkui.guidance.base.BaseGuidancePresenter;
 
@@ -45,11 +44,9 @@ public class GuidanceNextManeuverPresenter extends BaseGuidancePresenter {
      *         a {@link Context} to retrieve resources.
      * @param navigationManager
      *         a {@link NavigationManager} to be used for guidance handling.
-     * @param route
-     *         a route to be used for guidance.
      */
-    public GuidanceNextManeuverPresenter(Context context, NavigationManager navigationManager, Route route) {
-        super(navigationManager, route);
+    public GuidanceNextManeuverPresenter(Context context, NavigationManager navigationManager) {
+        super(navigationManager, null);
         mContext = context;
     }
 

--- a/MSDKUIKit/MSDKUILib/src/main/java/com/here/msdkui/guidance/GuidanceStreetLabelPresenter.java
+++ b/MSDKUIKit/MSDKUILib/src/main/java/com/here/msdkui/guidance/GuidanceStreetLabelPresenter.java
@@ -20,7 +20,6 @@ import android.content.Context;
 
 import com.here.android.mpa.guidance.NavigationManager;
 import com.here.android.mpa.routing.Maneuver;
-import com.here.android.mpa.routing.Route;
 import com.here.msdkui.R;
 import com.here.msdkui.common.ThemeUtil;
 import com.here.msdkui.guidance.base.BaseGuidancePresenter;
@@ -47,13 +46,9 @@ public class GuidanceStreetLabelPresenter extends BaseGuidancePresenter {
      *
      * @param navigationManager
      *         a {@link NavigationManager}.
-     *
-     * @param route
-     *         a {@link Route}.
      */
-    public GuidanceStreetLabelPresenter(Context context, NavigationManager navigationManager,
-                                        Route route) {
-        super(navigationManager, route);
+    public GuidanceStreetLabelPresenter(Context context, NavigationManager navigationManager) {
+        super(navigationManager, null);
         mContext = context;
     }
 


### PR DESCRIPTION
These presenters all require a route but seem to make no use of it and thus I have removed it from the presenters.

For example, `GuidanceEstimatedArrivalViewPresenter` already does this appropriately since it does not have a need for a route.