### PR TITLE
MSDKUI-2114: RP - App functionality stops after exiting settings twice

### DIFF
--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/RoutePlannerPresenter.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/routing/RoutePlannerPresenter.kt
@@ -160,6 +160,12 @@ class RoutePlannerPresenter : BasePresenter<RoutingContracts.RoutePlanner>() {
         router.calculateRoute(routePlan, object : CoreRouter.Listener {
             override fun onCalculateRouteFinished(inputList: List<RouteResult>, routingError: RoutingError) {
                 contract?.onProgress(false)
+                if (state.entryList.isEmpty() || !state.entryList.all { it.isValid }) {
+                    // If entryList is empty or invalid when route calculation ends then it means
+                    // that source waypoints has been cleared so result of this calculation
+                    // should be abandoned.
+                    return
+                }
                 if (inputList.isEmpty()) {
                     Log.e(RoutePlannerPresenter::class.java.name, "Routing failed  ${routingError.name}")
                     coordinatorListener?.onRoutingFailed(getString(R.string.msdkui_app_routeresults_error))


### PR DESCRIPTION
There are problems with app navigation logic in route planner at
situation when user press back during route calculation. Added check in
route calculation callback.

Signed-off-by: Tadeusz Staszak <36914750+tstaszak89@users.noreply.github.com>