### PR TITLE
MSDKUI-2311: Access to storage issue

### DIFF
--- a/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/base/BaseActivity.kt
+++ b/MSDKUIDemo/MSDKUIApp/src/main/java/com/here/msdkuiapp/base/BaseActivity.kt
@@ -18,6 +18,7 @@ package com.here.msdkuiapp.base
 
 import android.os.Bundle
 import android.os.Environment
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.here.android.mpa.common.MapSettings
 import com.here.msdkuiapp.common.AppActionBar
@@ -31,12 +32,18 @@ import java.io.File
  */
 @ContainerOptions(CacheImplementation.NO_CACHE)
 abstract class BaseActivity : AppCompatActivity() {
+    private val TAG = BaseActivity::class.java.name
 
     lateinit var appActionBar: AppActionBar
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        MapSettings.setDiskCacheRootPath(getMapDataPath())
+        try {
+            MapSettings.setDiskCacheRootPath(getMapDataPath())
+        } catch (e: IllegalArgumentException) {
+            Log.e(TAG, "Failed to set disk cache root path", e)
+        }
+
         appActionBar = AppActionBar(this).setUpActionBar()
     }
 

--- a/MSDKUIDemo/gradle.properties
+++ b/MSDKUIDemo/gradle.properties
@@ -40,9 +40,9 @@ gson_version=2.8.2
 play_service_version=17.0.0
 multidex_version=2.0.1
 # design lib
-appcompat_version=1.1.0
+appcompat_version=1.2.0
 constraint_layout_version=1.1.3
-android_material_version=1.1.0
+android_material_version=1.2.0
 # ui testing
 espresso_version=3.2.0
 test_version=1.2.0

--- a/MSDKUIKit/gradle.properties
+++ b/MSDKUIKit/gradle.properties
@@ -32,8 +32,8 @@ target_sdk_version=23
 min_sdk_version=19
 # design lib
 constraint_layout_version=1.1.3
-appcompat_version=1.1.0
-android_material_version=1.1.0
+appcompat_version=1.2.0
+android_material_version=1.2.0
 recyclerview_version=1.1.0
 # unit tests
 junit_version=4.12

--- a/MSDKUIKit/quality/spotbugs/spotbugs-filter.xml
+++ b/MSDKUIKit/quality/spotbugs/spotbugs-filter.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<SpotBugsFilter>
+<FindBugsFilter>
     <!-- http://stackoverflow.com/questions/7568579/eclipsefindbugs-exclude-filter-files-doesnt-work -->
     <Match>
         <Class name="~.*\.R\$.*"/>
@@ -32,4 +32,4 @@
     </Match>
 
 
-</SpotBugsFilter>
+</FindBugsFilter>


### PR DESCRIPTION
MapSettings.setDiskCacheRootPath() throws exception when it tries to set
external path without storage permission. Adding try catch fixes this
issue because user can't go beyond splash screen without accepting
storage permission.

Signed-off-by: Tadeusz Staszak <36914750+tstaszak89@users.noreply.github.com>